### PR TITLE
Fetch live fantasy premier league data

### DIFF
--- a/prediction_history.json
+++ b/prediction_history.json
@@ -1,0 +1,32 @@
+{
+  "predictions": [
+    {
+      "prediction_id": "points_1_2_20250830",
+      "player_id": "1",
+      "gameweek": 2,
+      "prediction_type": "points",
+      "predicted_value": 56.16,
+      "actual_value": null,
+      "confidence": 0.5,
+      "factors_used": {
+        "form": 8.0,
+        "value_per_point": 0.34375,
+        "minutes": "180",
+        "fixture_difficulty": 3.3333333333333335,
+        "total_points": "16",
+        "selected_by_percent": "21.2"
+      },
+      "timestamp": "2025-08-30 10:23:44.430928"
+    }
+  ],
+  "factor_weights": {
+    "form_weight": 0.3,
+    "value_weight": 0.25,
+    "minutes_weight": 0.2,
+    "recent_weight": 0.15,
+    "bonus_weight": 0.1,
+    "fixture_difficulty_weight": 0.15,
+    "injury_risk_weight": 0.1
+  },
+  "last_updated": "2025-08-30T10:23:44.430983"
+}


### PR DESCRIPTION
Ensure live FPL data, including the current team with transfers, is always fetched on dashboard refresh and add robust API request retries.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4f10dd8-9772-4d95-a6d2-ecc5c61aee96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4f10dd8-9772-4d95-a6d2-ecc5c61aee96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

